### PR TITLE
Octal parse error

### DIFF
--- a/plugins/libdhcpcd/dhcpcd.c
+++ b/plugins/libdhcpcd/dhcpcd.c
@@ -381,6 +381,7 @@ dhcpcd_decode_string_escape(char *dst, size_t dlen, const char *src)
 			case '\\':
 			case '0':
 			case '1':
+			case '2':
 			case '3':
 			case '4':
 			case '5':


### PR DESCRIPTION
We found we could not connect to SSIDs with certain characters, and tracked the problem back to here.